### PR TITLE
Update to rc6 and Added timezone ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ RUN apk add --update-cache \
         py-cryptography \
         ca-certificates
         
-# Mailpile read 
+# Mailpile read timezone from server, so in docker-compose you can change TZ
 RUN apk add --no-cache tzdata
 ENV TZ America/Lima
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,10 @@ RUN apk add --update-cache \
         py-cffi \
         py-cryptography \
         ca-certificates
+        
+# Mailpile read 
+RUN apk add --no-cache tzdata
+ENV TZ America/Lima
 
 # Get Mailpile from github
 RUN git clone https://github.com/mailpile/Mailpile.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update-cache \
         
 # Mailpile read timezone from server, so in docker-compose you can change TZ
 RUN apk add --no-cache tzdata
-ENV TZ America/Lima
+ENV TZ UTC
 
 # Get Mailpile from github
 RUN git clone https://github.com/mailpile/Mailpile.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,13 @@ MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
 ENV VERSION 1.0.0rc6
 ENV TZ "Etc/GMT"
+ENV MAILPILE_GNUPG/GA="/usr/bin/gpg-agent"
+ENV MAILPILE_GNUPG/DM="/usr/bin/dirmngr	"
 
 # Install requirements
 RUN apk add --update-cache \
         git \
+        tor \
         zlib \
         gnupg \
         gnupg1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM alpine
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
 ENV VERSION 1.0.0rc6
+ENV TZ "Etc/GMT"
 
 # Install requirements
 RUN apk add --update-cache \
@@ -23,7 +24,9 @@ RUN apk add --update-cache \
         
 # Mailpile read timezone from server, so in docker-compose you can change TZ
 RUN apk add --no-cache tzdata
-ENV TZ Etc/GMT
+
+RUN ln -sf "/usr/share/zoneinfo/$TZ" /etc/localtime && \
+    echo "$TZ" > /etc/timezone && date
 
 # Get Mailpile from github
 RUN git clone https://github.com/mailpile/Mailpile.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
 ENV VERSION 1.0.0rc6
 ENV TZ "Etc/GMT"
-ENV MAILPILE_GNUPG/GA="/usr/bin/gpg-agent"
-ENV MAILPILE_GNUPG/DM="/usr/bin/dirmngr	"
+ENV MAILPILE_GNUPG/GA "/usr/bin/gpg-agent"
+ENV MAILPILE_GNUPG/DM "/usr/bin/dirmngr"
 
 # Install requirements
 RUN apk add --update-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --update-cache \
         
 # Mailpile read timezone from server, so in docker-compose you can change TZ
 RUN apk add --no-cache tzdata
-ENV TZ UTC
+ENV TZ Etc/GMT
 
 # Get Mailpile from github
 RUN git clone https://github.com/mailpile/Mailpile.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 MAINTAINER Rafael Römhild <rafael@roemhild.de>
 
-ENV VERSION 1.0.0rc5
+ENV VERSION 1.0.0rc6
 
 # Install requirements
 RUN apk add --update-cache \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV VERSION 1.0.0rc6
 RUN apk add --update-cache \
         git \
         zlib \
+        gnupg \
         gnupg1 \
         py2-pip \
         openssl \


### PR DESCRIPTION
This pr update mailpile branch to rc6 and, because Mailpile uses timezone from image, add an ENV to change the timezone